### PR TITLE
Fix missing controller import

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\ProfileController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {


### PR DESCRIPTION
## Summary
- add missing ProfileController import to `routes/web.php`

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861be23e30483289b8f0e01aec655ac